### PR TITLE
Made hm.watchMethod() pass original arguments along to the interceptor.

### DIFF
--- a/src/helpme.js
+++ b/src/helpme.js
@@ -122,7 +122,7 @@
 
             if (this.isFunction(original)) {
                 object[method] = this.proxy(function () {
-                    callback.apply(this);
+                    callback.apply(this, arguments);
                     original.apply(object, arguments);
                 }, this);
             }

--- a/test/spec/WatchSpec.js
+++ b/test/spec/WatchSpec.js
@@ -29,4 +29,24 @@ describe('Watch Functions', function () {
         expect(callbackCalled).toBe(true);
         expect(methodCalled).toBe(true);
     });
+
+    it('hm.watchMethod() passes original arguments to interceptor', function () {
+        var expectedArguments = [5, 10];
+        var callbackArguments;
+        var methodArguments;
+        var test = {
+            method: function () {
+                methodArguments = Array.prototype.slice.call(arguments, 0);
+            }
+        };
+
+        hm.watchMethod(test, 'method', function () {
+            callbackArguments = Array.prototype.slice.call(arguments, 0);
+        });
+
+        test.method.apply(this, expectedArguments);
+
+        expect(callbackArguments).toEqual(expectedArguments);
+        expect(methodArguments).toEqual(expectedArguments);
+    });
 });


### PR DESCRIPTION
Now you can log arguments of methods that are being watched, to see what's being called and how!

Example:

``` javascript
var test = {
  method: function () {
    console.log('method called!');
    console.log(arguments);
  };
};

hm.watchMethod(test, 'method', function () {
  console.log('intercepted!');
  console.log(arguments);
});

test.method(1, 2, 3);
/*
 * Output:
 * intercepted!
 * [1, 2, 3]
 * method called!
 * [1, 2, 3]
 */
```
